### PR TITLE
Fix Reflect Abilities

### DIFF
--- a/FancyActionBar+/config.lua
+++ b/FancyActionBar+/config.lua
@@ -1130,23 +1130,23 @@ FancyActionBar.fakeClassEffects = {
 
 FancyActionBar.specialEffects = {
   [52790] = { id = 52790; stackId = 52790; isDebuff = true; forceShow = true }; -- Debuff Effect for the Taunt Counter
-  [35750] = { id = 35750; stackId = 35750; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; needCombatEvent = true }; -- Trap Beast Placed
+  [35750] = { id = 35750; stackId = 35750; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; onAbilityUsed = true; needCombatEvent = true }; -- Trap Beast Placed
   [35756] = { id = 35750; stackId = 35750; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true }; -- Trap Beast DOT
-  [40372] = { id = 40372; stackId = 40372; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; needCombatEvent = true }; -- Lightweight Trap Placed
+  [40372] = { id = 40372; stackId = 40372; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; onAbilityUsed = true; needCombatEvent = true }; -- Lightweight Trap Placed
   [40375] = { id = 40372; stackId = 40372; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true }; -- Lightweight Trap DOT
-  [40382] = { id = 40382; stackId = 40382; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; needCombatEvent = true }; -- Barbed Trap Placed
+  [40382] = { id = 40382; stackId = 40382; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; onAbilityUsed = true; needCombatEvent = true }; -- Barbed Trap Placed
   [40385] = { id = 40382; stackId = 40382; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true }; -- Barbed Trap DOT
   [40465] = { id = 40465; stackId = 40465; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true }; -- Scalding Rune Placed
   [40468] = { id = 40465; stackId = 40465; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true };  -- Scalding Rune DOT
 
-  [28727] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive posture
-  [126604] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive posture
+  [28727] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- defensive posture
+  [126604] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- defensive posture
 
-  [38312] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive stance
-  [126608] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive stance
+  [38312] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- defensive stance
+  [126608] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- defensive stance
 
-  [38317] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; needCombatEvent = true};  -- absorb missile
-  [38324] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; needCombatEvent = true};  -- absorb missile
+  [38317] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true };  -- absorb missile
+  [38324] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true };  -- absorb missile
 
 };
 
@@ -1179,9 +1179,9 @@ FancyActionBar.specialClassEffects = {
     [86015] = { id = 86015; stackId = 86015; fixedTime = true; duration = 3; stacks = 2; procs = 1; hasProced = 0 };  -- Deep Fissure, first proc
     [178028] = { id = 86015; stackId = 86015; fixedTime = true; duration = 6; stacks = 1; procs = 1; hasProced = 1 }; -- Deep Fissure, second proc
 
-    [86135] = {id = 86135; stackId = 86135; stacks = 3; isReflect = true; needCombatEvent = true}; -- crystallized shield
-    [86139] = {id = 86139; stackId = 86139; stacks = 3; isReflect = true; needCombatEvent = true}; -- crystallized slab
-    [86143] = {id = 86143; stackId = 86143; stacks = 3; isReflect = true; needCombatEvent = true}; -- shimmering shield
+    [86135] = {id = 86135; stackId = 86135; stacks = 3; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- crystallized shield
+    [86139] = {id = 86139; stackId = 86139; stacks = 3; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- crystallized slab
+    [86143] = {id = 86143; stackId = 86143; stacks = 3; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- shimmering shield
   
   };
   -- Arcanist

--- a/FancyActionBar+/config.lua
+++ b/FancyActionBar+/config.lua
@@ -1130,23 +1130,23 @@ FancyActionBar.fakeClassEffects = {
 
 FancyActionBar.specialEffects = {
   [52790] = { id = 52790; stackId = 52790; isDebuff = true; forceShow = true }; -- Debuff Effect for the Taunt Counter
-  [35750] = { id = 35750; stackId = 35750; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; onAbilityUsed = true; needCombatEvent = true }; -- Trap Beast Placed
+  [35750] = { id = 35750; stackId = 35750; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; needCombatEvent = true }; -- Trap Beast Placed
   [35756] = { id = 35750; stackId = 35750; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true }; -- Trap Beast DOT
-  [40372] = { id = 40372; stackId = 40372; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; onAbilityUsed = true; needCombatEvent = true }; -- Lightweight Trap Placed
+  [40372] = { id = 40372; stackId = 40372; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; needCombatEvent = true }; -- Lightweight Trap Placed
   [40375] = { id = 40372; stackId = 40372; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true }; -- Lightweight Trap DOT
-  [40382] = { id = 40382; stackId = 40382; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; onAbilityUsed = true; needCombatEvent = true }; -- Barbed Trap Placed
+  [40382] = { id = 40382; stackId = 40382; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; needCombatEvent = true }; -- Barbed Trap Placed
   [40385] = { id = 40382; stackId = 40382; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true }; -- Barbed Trap DOT
   [40465] = { id = 40465; stackId = 40465; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true }; -- Scalding Rune Placed
   [40468] = { id = 40465; stackId = 40465; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true };  -- Scalding Rune DOT
 
-  [28727] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- defensive posture
-  [126604] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- defensive posture
+  [28727] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive posture
+  [126604] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive posture
 
-  [38312] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- defensive stance
-  [126608] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- defensive stance
+  [38312] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive stance
+  [126608] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive stance
 
-  [38317] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true };  -- absorb missile
-  [38324] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; onAbilityUsed = true; needCombatEvent = true };  -- absorb missile
+  [38317] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; needCombatEvent = true};  -- absorb missile
+  [38324] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; needCombatEvent = true};  -- absorb missile
 
 };
 
@@ -1179,9 +1179,9 @@ FancyActionBar.specialClassEffects = {
     [86015] = { id = 86015; stackId = 86015; fixedTime = true; duration = 3; stacks = 2; procs = 1; hasProced = 0 };  -- Deep Fissure, first proc
     [178028] = { id = 86015; stackId = 86015; fixedTime = true; duration = 6; stacks = 1; procs = 1; hasProced = 1 }; -- Deep Fissure, second proc
 
-    [86135] = {id = 86135; stackId = 86135; stacks = 3; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- crystallized shield
-    [86139] = {id = 86139; stackId = 86139; stacks = 3; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- crystallized slab
-    [86143] = {id = 86143; stackId = 86143; stacks = 3; isReflect = true; onAbilityUsed = true; needCombatEvent = true }; -- shimmering shield
+    [86135] = {id = 86135; stackId = 86135; stacks = 3; isReflect = true; needCombatEvent = true}; -- crystallized shield
+    [86139] = {id = 86139; stackId = 86139; stacks = 3; isReflect = true; needCombatEvent = true}; -- crystallized slab
+    [86143] = {id = 86143; stackId = 86143; stacks = 3; isReflect = true; needCombatEvent = true}; -- shimmering shield
   
   };
   -- Arcanist

--- a/FancyActionBar+/config.lua
+++ b/FancyActionBar+/config.lua
@@ -801,6 +801,7 @@ FancyActionBar.stackMap = {
   -- Healing Springs Mag Recovey
   [40062] = {
     40062, -- Healing Springs
+    40060, -- Healing Springs
     99781, -- Grand Rejuviantion
   },
 };

--- a/FancyActionBar+/config.lua
+++ b/FancyActionBar+/config.lua
@@ -1130,23 +1130,23 @@ FancyActionBar.fakeClassEffects = {
 
 FancyActionBar.specialEffects = {
   [52790] = { id = 52790; stackId = 52790; isDebuff = true; forceShow = true }; -- Debuff Effect for the Taunt Counter
-  [35750] = { id = 35750; stackId = 35750; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; needCombatEvent = true }; -- Trap Beast Placed
+  [35750] = { id = 35750; stackId = 35750; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; onAbilityUsed = true; needCombatEvent = true }; -- Trap Beast Placed
   [35756] = { id = 35750; stackId = 35750; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true }; -- Trap Beast DOT
-  [40372] = { id = 40372; stackId = 40372; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; needCombatEvent = true }; -- Lightweight Trap Placed
+  [40372] = { id = 40372; stackId = 40372; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; onAbilityUsed = true; needCombatEvent = true }; -- Lightweight Trap Placed
   [40375] = { id = 40372; stackId = 40372; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true }; -- Lightweight Trap DOT
-  [40382] = { id = 40382; stackId = 40382; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; needCombatEvent = true }; -- Barbed Trap Placed
+  [40382] = { id = 40382; stackId = 40382; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true; forceExpireStacks = true; onAbilityUsed = true; needCombatEvent = true }; -- Barbed Trap Placed
   [40385] = { id = 40382; stackId = 40382; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true }; -- Barbed Trap DOT
   [40465] = { id = 40465; stackId = 40465; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true }; -- Scalding Rune Placed
   [40468] = { id = 40465; stackId = 40465; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true };  -- Scalding Rune DOT
 
-  [28727] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive posture
-  [126604] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive posture
+  [28727] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; onAbilityUsed = true; }; -- defensive posture
+  [126604] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; onAbilityUsed = true; }; -- defensive posture
 
-  [38312] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive stance
-  [126608] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive stance
+  [38312] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; onAbilityUsed = true; }; -- defensive stance
+  [126608] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; onAbilityUsed = true; }; -- defensive stance
 
-  [38317] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; needCombatEvent = true};  -- absorb missile
-  [38324] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; needCombatEvent = true};  -- absorb missile
+  [38317] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; onAbilityUsed = true; };  -- absorb missile
+  [38324] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; onAbilityUsed = true; };  -- absorb missile
 
 };
 
@@ -1179,9 +1179,9 @@ FancyActionBar.specialClassEffects = {
     [86015] = { id = 86015; stackId = 86015; fixedTime = true; duration = 3; stacks = 2; procs = 1; hasProced = 0 };  -- Deep Fissure, first proc
     [178028] = { id = 86015; stackId = 86015; fixedTime = true; duration = 6; stacks = 1; procs = 1; hasProced = 1 }; -- Deep Fissure, second proc
 
-    [86135] = {id = 86135; stackId = 86135; stacks = 3; isReflect = true; needCombatEvent = true}; -- crystallized shield
-    [86139] = {id = 86139; stackId = 86139; stacks = 3; isReflect = true; needCombatEvent = true}; -- crystallized slab
-    [86143] = {id = 86143; stackId = 86143; stacks = 3; isReflect = true; needCombatEvent = true}; -- shimmering shield
+    [86135] = {id = 86135; stackId = 86135; stacks = 3; isReflect = true; onAbilityUsed = true; }; -- crystallized shield
+    [86139] = {id = 86139; stackId = 86139; stacks = 3; isReflect = true; onAbilityUsed = true; }; -- crystallized slab
+    [86143] = {id = 86143; stackId = 86143; stacks = 3; isReflect = true; onAbilityUsed = true; }; -- shimmering shield
   
   };
   -- Arcanist

--- a/FancyActionBar+/config.lua
+++ b/FancyActionBar+/config.lua
@@ -1138,6 +1138,16 @@ FancyActionBar.specialEffects = {
   [40385] = { id = 40382; stackId = 40382; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true }; -- Barbed Trap DOT
   [40465] = { id = 40465; stackId = 40465; stacks = 1; procs = 1; hasProced = 0; isDebuff = false; keepOnTargetChange = true }; -- Scalding Rune Placed
   [40468] = { id = 40465; stackId = 40465; stacks = 0; procs = 1; hasProced = 1; isDebuff = true; keepOnTargetChange = true };  -- Scalding Rune DOT
+
+  [28727] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive posture
+  [126604] = { id = 28727; stackId = 28727; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive posture
+
+  [38312] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive stance
+  [126608] = { id = 38312; stackId = 38312; stacks = 1; isReflect = true; needCombatEvent = true}; -- defensive stance
+
+  [38317] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; needCombatEvent = true};  -- absorb missile
+  [38324] = { id = 38317; stackId = 38317; stacks = 1; isReflect = true; needCombatEvent = true};  -- absorb missile
+
 };
 
 -- The values as written to the ability corresponding to the id when the fade event happens, and are keyed based on modifying abiliity id and procs number
@@ -1168,6 +1178,11 @@ FancyActionBar.specialClassEffects = {
     [146919] = { id = 86019; stackId = 86019; fixedTime = true; duration = 3; stacks = 1; procs = 1; hasProced = 1 }; -- Sub Assault, second proc
     [86015] = { id = 86015; stackId = 86015; fixedTime = true; duration = 3; stacks = 2; procs = 1; hasProced = 0 };  -- Deep Fissure, first proc
     [178028] = { id = 86015; stackId = 86015; fixedTime = true; duration = 6; stacks = 1; procs = 1; hasProced = 1 }; -- Deep Fissure, second proc
+
+    [86135] = {id = 86135; stackId = 86135; stacks = 3; isReflect = true; needCombatEvent = true}; -- crystallized shield
+    [86139] = {id = 86139; stackId = 86139; stacks = 3; isReflect = true; needCombatEvent = true}; -- crystallized slab
+    [86143] = {id = 86143; stackId = 86143; stacks = 3; isReflect = true; needCombatEvent = true}; -- shimmering shield
+  
   };
   -- Arcanist
   [117] = {
@@ -1277,23 +1292,7 @@ FancyActionBar.frozen = {
   [86179] = true; -- frozen device
   [86183] = true; -- frozen retreat
 };
-FancyActionBar.iceShield = {
-  -- for tracking if able to absord projectiles.
-  [86135] = true, -- crystallized shield
-  [86139] = true, -- crystallized slab
-  [92168] = true; -- crystallized slab
-  [86143] = true, -- shimmering shield
-};
-FancyActionBar.reflects = {
-  -- to track the reflect / absorb charges.
-  -- abilities entered here will be updated with EVENT_COMBAT_EVENT 'OnReflect'.
-  [126604] = 28727, -- defensive posture
-  [126608] = 38312, -- defensive stance
-  [38324] = 38317,  -- absorb missile
-  [86135] = 86135,  -- crystallized shield
-  [86139] = 86139,  -- crystallized slab
-  [86143] = 86143,  -- shimmering shield
-};
+
 FancyActionBar.ignore = {
   -- filter for debugging.
   [63601] = true;  -- ESO Plus

--- a/FancyActionBar+/main.lua
+++ b/FancyActionBar+/main.lua
@@ -2457,11 +2457,12 @@ function FancyActionBar.HandleSpecial(id, change, updateTime, beginTime, endTime
 
   if FancyActionBar.specialEffects[id] then
     local specialEffect = ZO_DeepTableCopy(FancyActionBar.specialEffects[id]);
+    if specialEffect.isReflect then return end
     for effectId, effect in pairs(FancyActionBar.effects) do
       if effect.id == specialEffect.id then
         if (change == EFFECT_RESULT_GAINED or change == EFFECT_RESULT_UPDATED) then
           effect.beginTime = updateTime;
-          effect.endTime = updateTime + ((specialEffect.fixedTime and specialEffect.duration) or effect.duration or 0);
+          effect.endTime = updateTime + ((specialEffect.fixedTime and specialEffect.duration) or (change == EFFECT_RESULT_GAINED and (GetAbilityDuration(specialEffect.id) / 1000)) or effect.duration or 0);
           if specialEffect.stacks then
             FancyActionBar.stacks[specialEffect.stackId] = specialEffect.stacks;
           end;
@@ -3174,6 +3175,7 @@ function FancyActionBar.Initialize()
 
   local function OnReflect(_, result, _, aName, _, _, _, _, tName, tType, hit, _, _, _, _, tId, aId)
     if (tType ~= COMBAT_UNIT_TYPE_PLAYER) then return; end;
+    local doStackUpdate = false
 
     if SV.debugAll then
       local ts = tostring;
@@ -3181,24 +3183,29 @@ function FancyActionBar.Initialize()
       Chat(aName .. " (" .. ts(aId) .. ") || result: " .. ts(result) .. " || hit: " .. ts(hit));
       Chat("===================");
     end;
+    
+    local specialEffect = ZO_DeepTableCopy(FancyActionBar.specialEffects[aId]);
+    if not specialEffect.isReflect then return end
 
-    if (FancyActionBar.reflects[aId]) then
-      if (result == ACTION_RESULT_EFFECT_GAINED_DURATION) then
-        if FancyActionBar.iceShield[aId] then
-          FancyActionBar.stacks[FancyActionBar.reflects[aId]] = 3;
-        else
-          FancyActionBar.stacks[FancyActionBar.reflects[aId]] = 1;
-        end;
-      elseif (result == ACTION_RESULT_DAMAGE_SHIELDED and FancyActionBar.iceShield[aId]) then
-        FancyActionBar.stacks[FancyActionBar.reflects[aId]] = FancyActionBar.stacks[FancyActionBar.reflects[aId]] - 1;
-      elseif (result == ACTION_RESULT_EFFECT_FADED) then
-        FancyActionBar.stacks[FancyActionBar.reflects[aId]] = 0;
-      end;
-      FancyActionBar.HandleStackUpdate(FancyActionBar.reflects[aId]);
-    elseif (FancyActionBar.effects[aId] and result == ACTION_RESULT_EFFECT_FADED) then
-      FancyActionBar.stacks[aId] = 0;
-      FancyActionBar.HandleStackUpdate(aId);
+    if result == ACTION_RESULT_BEGIN or result == ACTION_RESULT_EFFECT_GAINED or result == ACTION_RESULT_EFFECT_GAINED_DURATION then
+      FancyActionBar.stacks[specialEffect.stackId] = specialEffect.stacks;
+      doStackUpdate = true
     end;
+
+    if result == ACTION_RESULT_DAMAGE_SHIELDED and FancyActionBar.stacks[specialEffect.stackId] and FancyActionBar.stacks[specialEffect.stackId] > 0 then
+      FancyActionBar.stacks[specialEffect.stackId] = FancyActionBar.stacks[specialEffect.stackId] - 1;
+      doStackUpdate = true
+    end
+
+    if (result == ACTION_RESULT_EFFECT_FADED) then
+      FancyActionBar.stacks[specialEffect.stackId] = 0;
+      doStackUpdate = true
+    end;
+      
+    if doStackUpdate == true then
+      FancyActionBar.HandleStackUpdate(specialEffect.id);
+    end;
+
   end;
 
   EM:UnregisterForEvent("ZO_ActionBar", EVENT_ACTIVE_COMPANION_STATE_CHANGED);
@@ -3303,12 +3310,11 @@ function FancyActionBar.Initialize()
     EM:AddFilterForEvent(NAME .. "GraveLordSacrifice", EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, FancyActionBar.graveLordSacrifice.eventId, REGISTER_FILTER_SOURCE_COMBAT_UNIT_TYPE, COMBAT_UNIT_TYPE_PLAYER_PET);
   end;
 
-  for i, x in pairs(FancyActionBar.reflects) do
-    EM:RegisterForEvent(NAME .. "Reflect" .. i, EVENT_COMBAT_EVENT, OnReflect);
-    EM:AddFilterForEvent(NAME .. "Reflect" .. i, EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, i);
-
-    EM:RegisterForEvent(NAME .. "Reflect" .. x, EVENT_COMBAT_EVENT, OnReflect);
-    EM:AddFilterForEvent(NAME .. "Reflect" .. x, EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, x, REGISTER_FILTER_COMBAT_RESULT, ACTION_RESULT_EFFECT_FADED);
+  for i, x in pairs(FancyActionBar.specialEffects) do
+    if x.isReflect then
+      EM:RegisterForEvent(NAME .. "Reflect" .. i, EVENT_COMBAT_EVENT, OnReflect);
+      EM:AddFilterForEvent(NAME .. "Reflect" .. i, EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, i);
+    end
   end;
 
   -- ZO_PreHook('ZO_ActionBar_OnActionButtonDown', function(slotNum)

--- a/FancyActionBar+/main.lua
+++ b/FancyActionBar+/main.lua
@@ -2868,7 +2868,7 @@ function FancyActionBar.Initialize()
             FancyActionBar.UpdateEffect(effect);
           elseif FancyActionBar.specialEffects[id] then
             local specialEffect = ZO_DeepTableCopy(FancyActionBar.specialEffects[id]);
-            if not specialEffect.needCombatEvent then return end
+            if not specialEffect.onAbilityUsed then return end
             for k, v in pairs(specialEffect) do effect[k] = v; end;
             effect.endTime = ((specialEffect.fixedTime and specialEffect.duration) or effect.duration or  0) + t;
             FancyActionBar.UpdateEffect(effect);
@@ -3300,9 +3300,9 @@ function FancyActionBar.Initialize()
     EM:AddFilterForEvent(NAME .. id, EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, id, REGISTER_FILTER_SOURCE_COMBAT_UNIT_TYPE, COMBAT_UNIT_TYPE_PLAYER);
   end;
 
-  for i in pairs(FancyActionBar.needCombatEvent) do
-    EM:RegisterForEvent(NAME .. i, EVENT_COMBAT_EVENT, OnCombatEvent);
-    EM:AddFilterForEvent(NAME .. i, EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, i, REGISTER_FILTER_SOURCE_COMBAT_UNIT_TYPE, COMBAT_UNIT_TYPE_PLAYER);
+  for id in pairs(FancyActionBar.needCombatEvent) do
+    EM:RegisterForEvent(NAME .. id, EVENT_COMBAT_EVENT, OnCombatEvent);
+    EM:AddFilterForEvent(NAME .. id, EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, id, REGISTER_FILTER_SOURCE_COMBAT_UNIT_TYPE, COMBAT_UNIT_TYPE_PLAYER);
   end;
 
   if FancyActionBar.graveLordSacrifice then
@@ -3310,10 +3310,10 @@ function FancyActionBar.Initialize()
     EM:AddFilterForEvent(NAME .. "GraveLordSacrifice", EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, FancyActionBar.graveLordSacrifice.eventId, REGISTER_FILTER_SOURCE_COMBAT_UNIT_TYPE, COMBAT_UNIT_TYPE_PLAYER_PET);
   end;
 
-  for i, x in pairs(FancyActionBar.specialEffects) do
-    if x.isReflect then
-      EM:RegisterForEvent(NAME .. "Reflect" .. i, EVENT_COMBAT_EVENT, OnReflect);
-      EM:AddFilterForEvent(NAME .. "Reflect" .. i, EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, i);
+  for id, effect in pairs(FancyActionBar.specialEffects) do
+    if effect.isReflect then
+      EM:RegisterForEvent(NAME .. "Reflect" .. id, EVENT_COMBAT_EVENT, OnReflect);
+      EM:AddFilterForEvent(NAME .. "Reflect" .. id, EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, id);
     end
   end;
 

--- a/FancyActionBar+/main.lua
+++ b/FancyActionBar+/main.lua
@@ -2868,7 +2868,7 @@ function FancyActionBar.Initialize()
             FancyActionBar.UpdateEffect(effect);
           elseif FancyActionBar.specialEffects[id] then
             local specialEffect = ZO_DeepTableCopy(FancyActionBar.specialEffects[id]);
-            if not specialEffect.onAbilityUsed then return end
+            if not specialEffect.needCombatEvent then return end
             for k, v in pairs(specialEffect) do effect[k] = v; end;
             effect.endTime = ((specialEffect.fixedTime and specialEffect.duration) or effect.duration or  0) + t;
             FancyActionBar.UpdateEffect(effect);
@@ -3118,86 +3118,93 @@ function FancyActionBar.Initialize()
   end;
 
   local function OnCombatEvent(_, result, _, aName, _, _, _, _, tName, tType, hit, _, _, _, _, tId, aId)
-    local doStackUpdate = false
-    local doEffectUpdate = false
     local effect;
     local t = time();
 
     local specialEffect = FancyActionBar.specialEffects[aId]
       and ZO_DeepTableCopy(FancyActionBar.specialEffects[aId]);
     local useSpecialDebuffTracking = SV.advancedDebuff and specialEffect and specialEffect.isSpecialDebuff;
-
-    if specialEffect and specialEffect.isReflect then
-      
-
-      if SV.debugAll then
-        local ts = tostring;
-        Chat("===================");
-        Chat(aName .. " (" .. ts(aId) .. ") || result: " .. ts(result) .. " || hit: " .. ts(hit));
-        Chat("===================");
-      end;
-
-      if result == ACTION_RESULT_BEGIN or result == ACTION_RESULT_EFFECT_GAINED or result == ACTION_RESULT_EFFECT_GAINED_DURATION then
-        FancyActionBar.stacks[specialEffect.stackId] = specialEffect.stacks;
-        doStackUpdate = true
-      end;
-      if result == ACTION_RESULT_DAMAGE_SHIELDED and FancyActionBar.stacks[specialEffect.stackId] and FancyActionBar.stacks[specialEffect.stackId] > 0 then
-        FancyActionBar.stacks[specialEffect.stackId] = FancyActionBar.stacks[specialEffect.stackId] - 1;
-        doStackUpdate = true
-      end
-      if (result == ACTION_RESULT_EFFECT_FADED) then
-        FancyActionBar.stacks[specialEffect.stackId] = 0;
-        doStackUpdate = true
-      end;
-      if doStackUpdate == true then
-        FancyActionBar.HandleStackUpdate(specialEffect.id);
-      end;
-
-    elseif specialEffect and not useSpecialDebuffTracking then
-
+    if specialEffect and not useSpecialDebuffTracking then
       FancyActionBar.HandleSpecial(aId, result, t, t, t + GetAbilityDuration(aId), _, tId);
       return;
+    end;
 
-    elseif (FancyActionBar.needCombatEvent[aId] and result == FancyActionBar.needCombatEvent[aId].result) then
+    if (FancyActionBar.needCombatEvent[aId] and result == FancyActionBar.needCombatEvent[aId].result) then
       effect = FancyActionBar.effects[aId];
       if effect then
         effect.endTime = time() + FancyActionBar.needCombatEvent[aId].duration;
-        doEffectUpdate = true
+        -- effect.faded = false
 
         -- local ts = tostring
         -- Chat('===================')
         -- Chat(aName..' ('..ts(aId)..') || result: '..ts(result)..' || hit: '..ts(hit))
         -- Chat('===================')
 
+        FancyActionBar.UpdateEffect(effect);
+        return;
       end;
-    elseif activeFakes[aId] and result == ACTION_RESULT_EFFECT_GAINED then
+    end;
 
+    if (result == ACTION_RESULT_EFFECT_GAINED and activeFakes[aId]) then
       activeFakes[aId] = false;
       effect = FancyActionBar.effects[aId];
       if effect then
         effect.endTime = time() + fakes[aId].duration;
-        doEffectUpdate = true
+
+        FancyActionBar.UpdateEffect(effect);
+
+        -- effect.faded = false
 
         -- local ts = tostring
         -- Chat('===================')
         -- Chat(aName..' ('..ts(aId)..') || result: '..ts(result)..' || hit: '..ts(hit))
         -- Chat('===================')
 
+        FancyActionBar.UpdateEffect(effect);
       end;
+    end;
 
-    elseif aId == FancyActionBar.graveLordSacrifice.eventId then
-
+    if aId == FancyActionBar.graveLordSacrifice.eventId then
       effect = FancyActionBar.effects[FancyActionBar.graveLordSacrifice.id];
       if effect then
         effect.endTime = time() + FancyActionBar.graveLordSacrifice.duration;
-        doEffectUpdate = true
+        FancyActionBar.UpdateEffect(effect);
       end;
+    end;
+  end;
 
+  local function OnReflect(_, result, _, aName, _, _, _, _, tName, tType, hit, _, _, _, _, tId, aId)
+    if (tType ~= COMBAT_UNIT_TYPE_PLAYER) then return; end;
+    local doStackUpdate = false
+
+    if SV.debugAll then
+      local ts = tostring;
+      Chat("===================");
+      Chat(aName .. " (" .. ts(aId) .. ") || result: " .. ts(result) .. " || hit: " .. ts(hit));
+      Chat("===================");
+    end;
+    
+    local specialEffect = ZO_DeepTableCopy(FancyActionBar.specialEffects[aId]);
+    if not specialEffect.isReflect then return end
+
+    if result == ACTION_RESULT_BEGIN or result == ACTION_RESULT_EFFECT_GAINED or result == ACTION_RESULT_EFFECT_GAINED_DURATION then
+      FancyActionBar.stacks[specialEffect.stackId] = specialEffect.stacks;
+      doStackUpdate = true
     end;
 
-    if effect and doEffectUpdate == true then
-      FancyActionBar.UpdateEffect(effect);
+    if result == ACTION_RESULT_DAMAGE_SHIELDED and FancyActionBar.stacks[specialEffect.stackId] and FancyActionBar.stacks[specialEffect.stackId] > 0 then
+      FancyActionBar.stacks[specialEffect.stackId] = FancyActionBar.stacks[specialEffect.stackId] - 1;
+      doStackUpdate = true
     end
+
+    if (result == ACTION_RESULT_EFFECT_FADED) then
+      FancyActionBar.stacks[specialEffect.stackId] = 0;
+      doStackUpdate = true
+    end;
+      
+    if doStackUpdate == true then
+      FancyActionBar.HandleStackUpdate(specialEffect.id);
+    end;
 
   end;
 
@@ -3301,6 +3308,13 @@ function FancyActionBar.Initialize()
   if FancyActionBar.graveLordSacrifice then
     EM:RegisterForEvent(NAME .. "GraveLordSacrifice", EVENT_COMBAT_EVENT, OnCombatEvent);
     EM:AddFilterForEvent(NAME .. "GraveLordSacrifice", EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, FancyActionBar.graveLordSacrifice.eventId, REGISTER_FILTER_SOURCE_COMBAT_UNIT_TYPE, COMBAT_UNIT_TYPE_PLAYER_PET);
+  end;
+
+  for i, x in pairs(FancyActionBar.specialEffects) do
+    if x.isReflect then
+      EM:RegisterForEvent(NAME .. "Reflect" .. i, EVENT_COMBAT_EVENT, OnReflect);
+      EM:AddFilterForEvent(NAME .. "Reflect" .. i, EVENT_COMBAT_EVENT, REGISTER_FILTER_ABILITY_ID, i);
+    end
   end;
 
   -- ZO_PreHook('ZO_ActionBar_OnActionButtonDown', function(slotNum)


### PR DESCRIPTION
- Reflects are now defined in specialEffects, and the OnReflect function has been reworked
- In specialEffects the flag for when something needs to be done when the ability is cast (onAbilityUsed) has been split from the flag for needing a combat event (needCombatEvent).
- Also add Missing ID for Healing Springs Stacks