### PR TITLE
Fix applying target counter settings

### DIFF
--- a/FancyActionBar+/main.lua
+++ b/FancyActionBar+/main.lua
@@ -1998,6 +1998,9 @@ function FancyActionBar.ApplySettings() -- apply all UI settings for current UI 
   FancyActionBar.ApplyStackFont();
   FancyActionBar.AdjustStackX();
 
+  FancyActionBar.ApplyTargetFont();
+  FancyActionBar.AdjustTargetX();
+
   FancyActionBar.AdjustUltTimer(false);
   FancyActionBar.ApplyUltFont(false);
 


### PR DESCRIPTION
There were not calls of `FancyActionBar.ApplyTargetFont` and `FancyActionBar.AdjustTargetX` in `FancyActionBar.ApplySettings` so settings from SV did not apply on initialization of add-on.